### PR TITLE
Set message content to null instead of empty string

### DIFF
--- a/google script.js
+++ b/google script.js
@@ -42,7 +42,7 @@ function onSubmit(e) {
             "Content-Type": "application/json",
         },
         "payload": JSON.stringify({
-            "content": "‌", // This is not an empty string
+            "content": null, // This is not an empty string
             "embeds": [{
                 "title": "TOP TEXT CHANGE THIS IN SCRIPT",
                 "fields": items,


### PR DESCRIPTION
Webhook messages should default to null instead of an empty string, to avoid extra gap between messages.,