### PR TITLE
Remove excess whitespace

### DIFF
--- a/google script.js
+++ b/google script.js
@@ -42,7 +42,6 @@ function onSubmit(e) {
             "Content-Type": "application/json",
         },
         "payload": JSON.stringify({
-            "content": "‌",
             "embeds": [{
                 "title": "Some nice title here",
               "color": 33023, // This is optional, you can look for decimal colour codes at https://www.webtoolkitonline.com/hexadecimal-decimal-color-converter.html


### PR DESCRIPTION
In my instance, the content field, although an empty string, seemed to cause a gap (where text would've been) between the webhook user and the embed itself. Removing the content field altogether seems to solve this for me.